### PR TITLE
chore: migrate rspack-contrib to rstackjs and fix npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24.14.1
+          registry-url: https://registry.npmjs.org
 
       - name: Setup Package Managers
         run: |
@@ -38,8 +39,6 @@ jobs:
 
       - name: Publish
         uses: JS-DevTools/npm-publish@v4
-        with:
-          token: empty
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The simplest and most flexible way to build with a compiling magic 🪄
 
-An Rsbuild plugin that allows you to create virtual modules, the pro version of [rspack-plugin-virtual-module](https://github.com/rspack-contrib/rspack-plugin-virtual-module) with loader API.
+An Rsbuild plugin that allows you to create virtual modules, the pro version of [rspack-plugin-virtual-module](https://github.com/rstackjs/rspack-plugin-virtual-module) with loader API.
 
 <p>
   <a href="https://npmjs.com/package/rsbuild-plugin-virtual-module">

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rspack-contrib/rsbuild-plugin-virtual-module"
+    "url": "git+https://github.com/rstackjs/rsbuild-plugin-virtual-module.git"
   },
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
This PR fixes the npm publish 404 error by:

1. Updating repository URL from `rspack-contrib` to `rstackjs` in `package.json` and `README.md`
2. Adding `registry-url` to `setup-node` step
3. Removing invalid `token: empty` from `JS-DevTools/npm-publish` to allow OIDC trusted publishing to work correctly

The 404 error was caused by the invalid token being passed to npm registry, which returns 404 for auth failures. Trusted publishing does not require an explicit token.