### PR TITLE
chore: update peer dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "6.0.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.0.0 || ^2.0.0-0"
+    "@rsbuild/core": "^1.0.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {


### PR DESCRIPTION
## Summary

This PR updates peer dependency ranges that still use the prerelease 2.0 floor (`^2.0.0-0`) to the stable 2.x range (`^2.0.0`). It keeps the existing compatibility alternatives where present and does not change runtime code.