### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "type": "git",
     "url": "git+https://github.com/rstackjs/rsbuild-plugin-virtual-module.git"
   },
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-virtual-module#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-virtual-module/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add the package homepage pointing to the repository README
- add the package bugs URL pointing to the repository issues page

## Why
The published npm metadata currently exposes the repository and license, but does not include `homepage` or `bugs` fields. Adding these fields makes the package support links easier to discover from npm and package tooling.

Current npm metadata checked with:

```bash
npm view rsbuild-plugin-virtual-module@latest name version repository homepage bugs license --json
```

```json
{
  "name": "rsbuild-plugin-virtual-module",
  "version": "0.4.4",
  "repository": {
    "url": "git+https://github.com/rstackjs/rsbuild-plugin-virtual-module.git",
    "type": "git"
  },
  "license": "MIT"
}
```

## Validation
- `node -e "const p=require('./package.json'); if(p.homepage !== 'https://github.com/rstackjs/rsbuild-plugin-virtual-module#readme') throw new Error('bad homepage'); if(!p.bugs || p.bugs.url !== 'https://github.com/rstackjs/rsbuild-plugin-virtual-module/issues') throw new Error('bad bugs url'); console.log(JSON.stringify({homepage:p.homepage, bugs:p.bugs}, null, 2));"`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`