### PR TITLE
docs: clarify virtual module plugin differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The simplest and most flexible way to build with a compiling magic 🪄
 
-An Rsbuild plugin that allows you to create virtual modules, the pro version of [rspack-plugin-virtual-module](https://github.com/rstackjs/rspack-plugin-virtual-module) with loader API.
+An Rsbuild plugin for generating virtual modules with async transform handlers, `loaderContext` APIs, and dependency-aware HMR, similar to webpack's [`VirtualUrlPlugin`](https://webpack.js.org/plugins/virtual-url-plugin/). It uses Rspack's [built-in `VirtualModulesPlugin`](https://rspack.rs/plugins/rspack/virtual-modules-plugin) under the hood.
 
 <p>
   <a href="https://npmjs.com/package/rsbuild-plugin-virtual-module">
@@ -44,6 +44,12 @@ import foo from 'virtual-foo';
 
 console.log(foo); // {}
 ```
+
+## What's the difference from Rspack's VirtualModulesPlugin?
+
+Rspack's built-in [`VirtualModulesPlugin`](https://rspack.rs/plugins/rspack/virtual-modules-plugin) accepts source strings and provides `writeModule` for imperative updates.
+
+This plugin is closer to webpack's [`VirtualUrlPlugin`](https://webpack.js.org/plugins/virtual-url-plugin/): an async [`TransformHandler`](https://rsbuild.dev/plugins/dev/core#apitransform) generates the module and exposes `loaderContext` APIs such as `addDependency` and `addContextDependency` to track changes and trigger HMR.
 
 ## Options
 


### PR DESCRIPTION
## Summary

- clarify that the plugin uses Rspack's built-in `VirtualModulesPlugin`
- compare its async transform API with webpack's `VirtualUrlPlugin`
- document `loaderContext` dependency tracking and HMR behavior

## Testing

- `npm run lint`
